### PR TITLE
Email breakout

### DIFF
--- a/SQL_MIGRATIONS.md
+++ b/SQL_MIGRATIONS.md
@@ -1,0 +1,5 @@
+2/12/2017
+---------
+```sql
+ALTER TABLE monero_live.config MODIFY item_value TEXT;
+```

--- a/deployment/base.sql
+++ b/deployment/base.sql
@@ -42,7 +42,7 @@ CREATE TABLE config
     id INT(11) PRIMARY KEY NOT NULL AUTO_INCREMENT,
     module VARCHAR(32),
     item VARCHAR(32),
-    item_value VARCHAR(128),
+    item_value TEXT,
     item_type VARCHAR(64),
     Item_desc VARCHAR(512)
 );

--- a/deployment/base.sql
+++ b/deployment/base.sql
@@ -223,6 +223,9 @@ INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES 
 INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES ('payout', 'rpcPasswordPath', '', 'string', 'Path and file for the RPC password file location');
 INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES ('payout', 'maxPaymentTxns', '5', 'int', 'Maximum number of transactions in a single payment');
 INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES ('general', 'shareHost', '', 'string', 'Host that receives share information');
+INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES ('email', 'workerNotHashingBody', 'Hello,\n\nYour worker: %(worker)s has stopped submitting hashes at: %(timestamp)s UTC\n\nThank you,\n%(poolEmailSig)s', 'string', 'Email sent to the miner when their worker stops hashing');
+INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES ('email', 'workerNotHashingSubject', 'Worker %(worker)s stopped hashing', 'string', 'Subject of email sent to miner when worker stops hashing');
+INSERT INTO pool.config (module, item, item_value, item_type, Item_desc) VALUES ('general', 'emailSig', 'NodeJS-Pool Administration Team', 'string', 'Signature line for the emails.');
 INSERT INTO pool.users (username, pass, email, admin, payout_threshold) VALUES ('Administrator', null, 'Password123', 1, 0);
 INSERT INTO pool.port_config (poolPort, difficulty, portDesc, portType, hidden, `ssl`) VALUES (3333, 1000, 'Low-End Hardware (Up to 30-40 h/s)', 'pplns', 0, 0);
 INSERT INTO pool.port_config (poolPort, difficulty, portDesc, portType, hidden, `ssl`) VALUES (5555, 5000, 'Medium-Range Hardware (Up to 160 h/s)', 'pplns', 0, 0);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,6 +1,7 @@
 "use strict";
 const debug = require("debug")("worker");
 const async = require("async");
+const sprintf = require("sprintf-js").sprintf;
 
 let threadName = "Worker Server ";
 let cycleCount = 0;
@@ -214,9 +215,14 @@ function updateShareStats() {
                                         return;
                                     }
                                     // toAddress, subject, body
-                                    global.support.sendEmail(rows[0].email, "Worker " + worker + " not hashing",
-                                        "Hello,\r\n\r\nYour worker: " + worker + " has stopped submitting hashes at: " + global.support.formatDate(Date.now()) +
-                                        " UTC\r\n\r\nThank you,\r\nXMRPool.net Administration Team");
+                                    let emailData = {
+                                        worker: worker,
+                                        timestamp: global.support.formatDate(Date.now()),
+                                        poolEmailSig: global.config.general.emailSig
+                                    };
+                                    global.support.sendEmail(rows[0].email,
+                                        sprintf(global.config.email.workerNotHashingSubject, emailData),
+                                        sprintf(global.config.email.workerNotHashingBody, emailData));
                                 });
                             }
                             minerStats.hash = 0;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "request": "^2.79.0",
     "request-json": "0.6.1",
     "shapeshift.io": "1.3.0",
+    "sprintf-js": "^1.0.3",
     "uuid": "3.0.1",
     "wallet-address-validator": "0.1.0"
   }

--- a/sql_sync/config_entries.json
+++ b/sql_sync/config_entries.json
@@ -510,5 +510,29 @@
     "item_value": "",
     "item_type": "string",
     "Item_desc": "Host that receives share information"
+  },
+  {
+    "id": 70,
+    "module": "email",
+    "item": "workerNotHashingBody",
+    "item_value": "Hello,\n\nYour worker: %(worker)s has stopped submitting hashes at: %(timestamp)s UTC\n\nThank you,\n%(poolEmailSig)",
+    "item_type": "string",
+    "Item_desc": "Email sent to the miner when their worker stops hashing"
+  },
+  {
+    "id": 71,
+    "module": "email",
+    "item": "workerNotHashingSubject",
+    "item_value": "Worker %(worker)s stopped hashing",
+    "item_type": "string",
+    "Item_desc": "Subject of email sent to miner when worker stops hashing"
+  },
+  {
+    "id": 72,
+    "module": "general",
+    "item": "emailSig",
+    "item_value": "NodeJS-Pool Administration Team",
+    "item_type": "string",
+    "Item_desc": "Signature line for the emails."
   }
 ]

--- a/sql_sync/config_entries.json
+++ b/sql_sync/config_entries.json
@@ -515,7 +515,7 @@
     "id": 70,
     "module": "email",
     "item": "workerNotHashingBody",
-    "item_value": "Hello,\n\nYour worker: %(worker)s has stopped submitting hashes at: %(timestamp)s UTC\n\nThank you,\n%(poolEmailSig)",
+    "item_value": "Hello,\n\nYour worker: %(worker)s has stopped submitting hashes at: %(timestamp)s UTC\n\nThank you,\n%(poolEmailSig)s",
     "item_type": "string",
     "Item_desc": "Email sent to the miner when their worker stops hashing"
   },


### PR DESCRIPTION
Email updates so pool ops can modify their ownership of the e-mails more directly.  If already installed, please run the following:
From SQL - ALTER TABLE monero_live.config MODIFY item_value TEXT;
From shell - npm install
Then perform a SQL sync per the procedures in the readme to load the new values.

Worker is the only daemon effected by this change for now.