### PR TITLE
Generate smaller job ids.

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -445,7 +445,7 @@ function Miner(id, login, pass, ipAddress, startingDiff, messageSender, protoVer
 
 
             let newJob = {
-                id: uuidV4(),
+                id: crypto.pseudoRandomBytes(21).toString('base64'),
                 extraNonce: activeBlockTemplate.extraNonce,
                 height: activeBlockTemplate.height,
                 difficulty: this.difficulty,


### PR DESCRIPTION
Because wolf-xmr-miner supports up to 31 bytes ids.

https://github.com/wolf9466/wolf-xmr-miner/blob/master/stratum.h#L10
https://github.com/wolf9466/wolf-xmr-miner/blob/master/main.c#L1241