### PR TITLE
Fixes roundHashes not resetting

### DIFF
--- a/lib/local_comms.js
+++ b/lib/local_comms.js
@@ -206,7 +206,7 @@ function Database(){
                 if (!cachedData.global_stats.hasOwnProperty('totalHashes') || cachedData.global_stats.totalHashes === null) {
                     cachedData.global_stats.totalHashes = 0;
                 }
-                if (!cachedData.global_stats.hasOwnProperty('roundHashes') || cachedData.global_stats.roundHashes === null) {
+                if (!cachedData.global_stats.hasOwnProperty('roundHashes') || cachedData.global_stats.roundHashes === null || share.foundBlock) {
                     cachedData.global_stats.roundHashes = 0;
                 }
                 cachedData.global_stats.totalHashes += share.shares;
@@ -226,7 +226,7 @@ function Database(){
                 if (!cachedData[stats_type].hasOwnProperty('totalHashes') || cachedData[stats_type].totalHashes === null) {
                     cachedData[stats_type].totalHashes = 0;
                 }
-                if (!cachedData[stats_type].hasOwnProperty('roundHashes') || cachedData[stats_type].roundHashes === null) {
+                if (!cachedData[stats_type].hasOwnProperty('roundHashes') || cachedData[stats_type].roundHashes === null || share.foundBlock) {
                     cachedData[stats_type].roundHashes = 0;
                 }
                 cachedData[stats_type].totalHashes += share.shares;
@@ -277,7 +277,7 @@ function Database(){
                     if (shares.hasOwnProperty(key)){
                         blocksSeen += 1;
                         let sharesSeen = 0;
-                        shares[key].forEach(function(final_share){
+                        shares[key].forEach(function(final_share){  // jshint ignore:line
                             sharesSeen += 1;
                             try {
                                 txn.putBinary(global.database.shareDB, parseInt(key), global.protos.Share.encode(final_share));
@@ -478,7 +478,7 @@ function Database(){
         let blockProto = txn.getBinary(this.blockDB, blockId);
         if (blockProto !== null){
             let blockData = global.protos.Block.decode(blockProto);
-            blockData['unlocked'] = false;
+            blockData.unlocked = false;
             txn.putBinary(this.blockDB, blockId, global.protos.Block.encode(blockData));
         }
         txn.commit();
@@ -618,18 +618,7 @@ function Database(){
     };
 
 
-    this.refreshEnv = function(){
-        if (this.dirtyenv === true){
-            /*
-            console.log("Database Worker: Reloading LMDB Env");
-            global.database.env.sync(function(){
-            });
-            clearInterval(this.intervalID);
-            global.database.env.close();
-            this.initEnv();
-            */
-        }
-    };
+    this.refreshEnv = function(){};
 
     setInterval(function(){
         global.database.dirtyenv = true;

--- a/package.json
+++ b/package.json
@@ -20,13 +20,11 @@
     "concat-stream": "^1.6.0",
     "cors": "^2.8.1",
     "crypto": "0.0.3",
-    "cryptonote-util": "git://github.com/Snipa22/node-cryptonote-util.git#xmr-Nan-2.0",
     "debug": "2.5.1",
     "express": "4.14.0",
     "jsonwebtoken": "^7.2.1",
     "minimist": "1.2.0",
     "moment": "2.17.1",
-    "multi-hashing": "git+https://github.com/Snipa22/node-multi-hashing-aesni.git",
     "mysql": "2.12.0",
     "node-lmdb": "0.4.12",
     "promise-mysql": "3.0.0",
@@ -42,5 +40,9 @@
     "uuid": "3.0.1",
     "wallet-address-validator": "0.1.0",
     "zmq": "^2.15.3"
+  },
+  "optionalDependencies": {
+    "cryptonote-util": "git://github.com/Snipa22/node-cryptonote-util.git#xmr-Nan-2.0",
+    "multi-hashing": "git+https://github.com/Snipa22/node-multi-hashing-aesni.git"
   }
 }


### PR DESCRIPTION
Fix for #72
Issue is that the system may have a loaded chunk of shares to work on at the time of the block find, causing the cashed values to load instead.

Prep work for adding more coins.  Moving the multi-hashing AES-NI lib + the CN-Utils lib to optional requirements.