### PR TITLE
Fix longRunner error in local_comms.js

### DIFF
--- a/lib/local_comms.js
+++ b/lib/local_comms.js
@@ -635,7 +635,7 @@ function Database(){
                     debug("Scanning block: " + blockID);
                     let txn = global.database.env.beginTxn({readOnly: true});
                     let cursor = new global.database.lmdb.Cursor(txn, global.database.shareDB);
-                    for (let found = (cursor.goToRange(blockID) === blockID); found; found = cursor.goToNextDup()) {
+                    for (let found = (cursor.goToRange(parseInt(blockID)) === blockID); found; found = cursor.goToNextDup()) {
                         if (pplnsFound){
                             cursor.getCurrentBinary(function(key, data) {  // jshint ignore:line
                                 if (blockList.indexOf(key) === -1){


### PR DESCRIPTION
This fix solves the longRunner throwing errors after updating to NVM 8.9.3. Should solve problems described in #217 and #230.