### PR TITLE
Fixed the timestamp calculation in seconds

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -333,7 +333,7 @@ function Miner(id, login, pass, ipAddress, startingDiff, messageSender, protoVer
     // VarDiff System
     this.shareTimeBuffer = global.support.circularBuffer(8);
     this.shareTimeBuffer.enq(global.config.pool.targetTime);
-    this.lastShareTime = Date.now() / 1000 || 0;
+    this.lastShareTime = Math.floor(Date.now() / 1000);
 
     this.validShares = 0;
     this.invalidShares = 0;


### PR DESCRIPTION
The old code was wrong as it was using logical OR instead of bitwise OR for this dirty hack. Beside that this old approach (if used correctly with "|" instead of "||") would break in 2039 as it'd produce negative numbers.