### PR TITLE
Fixes: you specified keyIsUint32 on the Dbi

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -127,7 +127,7 @@ function updateShareStats() {
             }, function (oldestTime) {
                 height -= 1;
                 loopBreakout += 1;
-                if (loopBreakout > 60) {
+                if (loopBreakout > 60 || height < 0) {
                     return true;
                 }
                 return oldestTime <= identifierTime;


### PR DESCRIPTION
Fixes bug where height becomes < 0 and causes error on line 43: `Error: You specified keyIsUint32 on the Dbi, so you can't use other key types with it.`