### PR TITLE
Allow passing of --config [FILENAME] to init.js

### DIFF
--- a/init.js
+++ b/init.js
@@ -2,7 +2,7 @@
 let mysql = require("promise-mysql");
 let fs = require("fs");
 let argv = require('minimist')(process.argv.slice(2));
-let config = fs.readFileSync("./config.json");
+let config = fs.readFileSync("./" + (argv.config || "config.json"));
 let coinConfig = fs.readFileSync("./coinConfig.json");
 let protobuf = require('protocol-buffers');
 let path = require('path');


### PR DESCRIPTION
More flexibility for testing different configs, different environments, reusing same codebase for different coins, etc

e.g.

`node init.js --config=config-dev.json`