### PR TITLE
Improve error management when interacting with coin daemon.

### DIFF
--- a/debug_scripts/block_migrator_from_old_sql.js
+++ b/debug_scripts/block_migrator_from_old_sql.js
@@ -94,11 +94,13 @@ global.mysql.query("SELECT * FROM config").then(function (rows) {
                default:
                    block.poolType = global.protos.POOLTYPE.PPLNS;
            }
-           global.coinFuncs.getBlockHeaderByHash(block.hash, function(header){
-               block.value = header.reward;
-               let txn = global.database.env.beginTxn();
-               txn.putBinary(global.database.blockDB, row.height, global.protos.Block.encode(block));
-               txn.commit();
+           global.coinFuncs.getBlockHeaderByHash(block.hash, function(err, header) {
+                if (!err) {
+                    block.value = header.reward;
+                    let txn = global.database.env.beginTxn();
+                    txn.putBinary(global.database.blockDB, row.height, global.protos.Block.encode(block));
+                    txn.commit();
+                }
            });
        });
    });

--- a/lib/blockManager.js
+++ b/lib/blockManager.js
@@ -428,7 +428,7 @@ function blockPayments(block) {
             break;
         case global.protos.POOLTYPE.PPLNS:
             global.coinFuncs.getBlockHeaderByHash(block.hash, function (err, header) {
-                if (err === null){
+                if (!err){
                     calculatePPLNSPayments(header);
                     global.database.unlockBlock(block.hash);
                 }
@@ -436,7 +436,7 @@ function blockPayments(block) {
             break;
         case global.protos.POOLTYPE.SOLO:
             global.coinFuncs.getBlockHeaderByHash(block.hash, function (err, header) {
-                if (err === null){
+                if (!err){
                     calculateSoloPayments(header);
                     global.database.unlockBlock(block.hash);
                 }
@@ -457,7 +457,7 @@ function blockScanner() {
     }
     scanInProgress = true;
     global.coinFuncs.getLastBlockHeader(function (err, blockHeader) {
-        if (err === null){
+        if (!err){
             if (lastBlock === blockHeader.height) {
                 debug("No new work to be performed, block header matches last block");
                 scanInProgress = false;
@@ -482,7 +482,7 @@ function blockScanner() {
                 blockScannerTask = setInterval(blockScanner, 1000);
             }
         } else {
-            console.error(`Upstream error from the block daemon.  Resetting scanner due to: ${JSON.stringify(blockHeader)}`);
+            console.error(`Upstream error from the block daemon. Resetting scanner due to: ${JSON.stringify(blockHeader)}`);
             scanInProgress = false;
             blockScannerTask = setInterval(blockScanner, 1000);
         }

--- a/lib/coins/aeon.js
+++ b/lib/coins/aeon.js
@@ -7,6 +7,11 @@ const debug = require('debug')('coinFuncs');
 
 let hexChars = new RegExp("[0-9a-f]+");
 
+function handleDaemonError(err, body, callback) {
+    console.error(JSON.stringify(body));
+    callback(new Error(`${err} RPC: ${JSON.stringify(body)}`))
+}
+
 function Coin(data){
     this.bestExchange = global.config.payout.bestExchange;
     this.data = data;
@@ -28,46 +33,32 @@ function Coin(data){
 
     this.niceHashDiff = 400000;
 
-    this.getBlockHeaderByID = function(blockId, callback){
-        global.support.rpcDaemon('getblockheaderbyheight', {"height": blockId}, function (body) {
-            if (body.hasOwnProperty('result')){
-                return callback(null, body.result.block_header);
-            } else {
-                console.error(JSON.stringify(body));
-                return callback(true, body);
-            }
-        });
+    this.getBlockHeaderByHeight = (height, callback) => { // unused
+        global.support.rpcDaemon('getblockheaderbyheight', { height }, (body) => body && body,result && body.result.block_header
+            ? callback(null, body.result.block_header)
+            : handleDaemonError(`RPC 'getblockheaderbyheight' to aeon daemon failed to return the block header.`, body, callback)
+        );
     };
 
-    this.getBlockHeaderByHash = function(blockHash, callback){
-        global.support.rpcDaemon('getblockheaderbyhash', {"hash": blockHash}, function (body) {
-            if (typeof(body) !== 'undefined' && body.hasOwnProperty('result')){
-                return callback(null, body.result.block_header);
-            } else {
-                console.error(JSON.stringify(body));
-                return callback(true, body);
-            }
-        });
+    this.getBlockHeaderByHash = (hash, callback) => {
+        global.support.rpcDaemon('getblockheaderbyhash', { hash }, (body) => body && body,result && body.result.block_header
+            ? callback(null, body.result.block_header)
+            : handleDaemonError(`RPC 'getblockheaderbyhash' to aeon daemon failed to return the block header.`, body, callback)
+        );
     };
 
-    this.getLastBlockHeader = function(callback){
-        global.support.rpcDaemon('getlastblockheader', [], function (body) {
-            if (typeof(body) !== 'undefined' && body.hasOwnProperty('result')){
-                return callback(null, body.result.block_header);
-            } else {
-                console.error(JSON.stringify(body));
-                return callback(true, body);
-            }
-        });
+    this.getLastBlockHeader = (callback) => {
+        global.support.rpcDaemon('getlastblockheader', {}, (body) => body && body.result && body.result.block_header
+            ? callback(null, body.result.block_header)
+            : handleDaemonError(`RPC 'getlastblockheader' to aeon daemon failed to return the block header.`, body, callback)
+        );
     };
 
-    this.getBlockTemplate = function(walletAddress, callback){
-        global.support.rpcDaemon('getblocktemplate', {
-            reserve_size: 17,
-            wallet_address: walletAddress
-        }, function(body){
-            return callback(body);
-        });
+    this.getBlockTemplate = (wallet_address, callback) => {
+        global.support.rpcDaemon('getblocktemplate', { reserve_size: 17, wallet_address }, (body) => body && body.result
+            ? callback(null, body)
+            : handleDaemonError(`RPC 'getblocktemplate' to aeon daemon failed to return the block template.`, body, callback)
+        );
     };
 
     this.baseDiff = function(){

--- a/lib/coins/krb.js
+++ b/lib/coins/krb.js
@@ -7,6 +7,11 @@ const debug = require('debug')('coinFuncs');
 
 let hexChars = new RegExp("[0-9a-f]+");
 
+function handleDaemonError(err, body, callback) {
+    console.error(JSON.stringify(body));
+    callback(new Error(`${err} RPC: ${JSON.stringify(body)}`), null)
+}
+
 function Coin(data){
     this.bestExchange = global.config.payout.bestExchange;
     this.data = data;
@@ -28,46 +33,32 @@ function Coin(data){
 
     this.niceHashDiff = 200000;
 
-    this.getBlockHeaderByID = function(blockId, callback){
-        global.support.rpcDaemon('getblockheaderbyheight', {"height": blockId}, function (body) {
-            if (body.hasOwnProperty('result')){
-                return callback(null, body.result.block_header);
-            } else {
-                console.error(JSON.stringify(body));
-                return callback(true, body);
-            }
-        });
+    this.getBlockHeaderByHeight = (height, callback) => { // unused
+        global.support.rpcDaemon('getblockheaderbyheight', { height }, (body) => body && body,result && body.result.block_header
+            ? callback(null, body.result.block_header)
+            : handleDaemonError(`RPC 'getblockheaderbyheight' to krb daemon failed to return the block header.`, body, callback)
+        );
     };
 
-    this.getBlockHeaderByHash = function(blockHash, callback){
-        global.support.rpcDaemon('getblockheaderbyhash', {"hash": blockHash}, function (body) {
-            if (typeof(body) !== 'undefined' && body.hasOwnProperty('result')){
-                return callback(null, body.result.block_header);
-            } else {
-                console.error(JSON.stringify(body));
-                return callback(true, body);
-            }
-        });
+    this.getBlockHeaderByHash = (hash, callback) => {
+        global.support.rpcDaemon('getblockheaderbyhash', { hash }, (body) => body && body,result && body.result.block_header
+            ? callback(null, body.result.block_header)
+            : handleDaemonError(`RPC 'getblockheaderbyhash' to krb daemon failed to return the block header.`, body, callback)
+        );
     };
 
-    this.getLastBlockHeader = function(callback){
-        global.support.rpcDaemon('getlastblockheader', [], function (body) {
-            if (typeof(body) !== 'undefined' && body.hasOwnProperty('result')){
-                return callback(null, body.result.block_header);
-            } else {
-                console.error(JSON.stringify(body));
-                return callback(true, body);
-            }
-        });
+    this.getLastBlockHeader = (callback) => {
+        global.support.rpcDaemon('getlastblockheader', {}, (body) => body && body.result && body.result.block_header
+            ? callback(null, body.result.block_header)
+            : handleDaemonError(`RPC 'getlastblockheader' to krb daemon failed to return the block header.`, body, callback)
+        );
     };
 
-    this.getBlockTemplate = function(walletAddress, callback){
-        global.support.rpcDaemon('getblocktemplate', {
-            reserve_size: 17,
-            wallet_address: walletAddress
-        }, function(body){
-            return callback(body);
-        });
+    this.getBlockTemplate = (wallet_address, callback) => {
+        global.support.rpcDaemon('getblocktemplate', { reserve_size: 17, wallet_address }, (body) => body && body.result
+            ? callback(null, body)
+            : handleDaemonError(`RPC 'getblocktemplate' to krb daemon failed to return the block template.`, body, callback)
+        );
     };
 
     this.baseDiff = function(){

--- a/lib/coins/xmr.js
+++ b/lib/coins/xmr.js
@@ -7,6 +7,11 @@ const debug = require('debug')('coinFuncs');
 
 let hexChars = new RegExp("[0-9a-f]+");
 
+function handleDaemonError(err, body, callback) {
+    console.error(JSON.stringify(body));
+    callback(new Error(`${err} RPC: ${JSON.stringify(body)}`), null)
+}
+
 function Coin(data){
     this.bestExchange = global.config.payout.bestExchange;
     this.data = data;
@@ -42,46 +47,32 @@ function Coin(data){
 
     this.niceHashDiff = 400000;
 
-    this.getBlockHeaderByID = function(blockId, callback){
-        global.support.rpcDaemon('getblockheaderbyheight', {"height": blockId}, function (body) {
-            if (body.hasOwnProperty('result')){
-                return callback(null, body.result.block_header);
-            } else {
-                console.error(JSON.stringify(body));
-                return callback(true, body);
-            }
-        });
+    this.getBlockHeaderByHeight = (height, callback) => { // unused
+        global.support.rpcDaemon('getblockheaderbyheight', { height }, (body) => body && body,result && body.result.block_header
+            ? callback(null, body.result.block_header)
+            : handleDaemonError(`RPC 'getblockheaderbyheight' to monero daemon failed to return the block header.`, body, callback)
+        );
     };
 
-    this.getBlockHeaderByHash = function(blockHash, callback){
-        global.support.rpcDaemon('getblockheaderbyhash', {"hash": blockHash}, function (body) {
-            if (typeof(body) !== 'undefined' && body.hasOwnProperty('result')){
-                return callback(null, body.result.block_header);
-            } else {
-                console.error(JSON.stringify(body));
-                return callback(true, body);
-            }
-        });
+    this.getBlockHeaderByHash = (hash, callback) => {
+        global.support.rpcDaemon('getblockheaderbyhash', { hash }, (body) => body && body,result && body.result.block_header
+            ? callback(null, body.result.block_header)
+            : handleDaemonError(`RPC 'getblockheaderbyhash' to monero daemon failed to return the block header.`, body, callback)
+        );
     };
 
-    this.getLastBlockHeader = function(callback){
-        global.support.rpcDaemon('getlastblockheader', [], function (body) {
-            if (typeof(body) !== 'undefined' && body.hasOwnProperty('result')){
-                return callback(null, body.result.block_header);
-            } else {
-                console.error(JSON.stringify(body));
-                return callback(true, body);
-            }
-        });
+    this.getLastBlockHeader = (callback) => {
+        global.support.rpcDaemon('getlastblockheader', {}, (body) => body && body.result && body.result.block_header
+            ? callback(null, body.result.block_header)
+            : handleDaemonError(`RPC 'getlastblockheader' to monero daemon failed to return the block header.`, body, callback)
+        );
     };
 
-    this.getBlockTemplate = function(walletAddress, callback){
-        global.support.rpcDaemon('getblocktemplate', {
-            reserve_size: 17,
-            wallet_address: walletAddress
-        }, function(body){
-            return callback(body);
-        });
+    this.getBlockTemplate = (wallet_address, callback) => {
+        global.support.rpcDaemon('getblocktemplate', { reserve_size: 17, wallet_address }, (body) => body && body.result
+            ? callback(null, body.result)
+            : handleDaemonError(`RPC 'getblocktemplate' to monero daemon failed to return the block template.`, body, callback)
+        );
     };
 
     this.baseDiff = function(){

--- a/lib/local_comms.js
+++ b/lib/local_comms.js
@@ -410,7 +410,7 @@ function Database(){
         txn.abort();
         let blockDataDecoded = global.protos.Block.decode(blockData);
         global.coinFuncs.getBlockHeaderByHash(blockDataDecoded.hash, function(err, header){
-            if (err === null) {
+            if (!err) {
                 blockDataDecoded.value = header.reward;
                 blockData = global.database.calculateShares(blockDataDecoded, blockId);
                 let txn = global.database.env.beginTxn();
@@ -582,14 +582,20 @@ function Database(){
                     callback(null, oldestLockedBlock)
                 } else {
                     global.coinFuncs.getBlockHeaderByHash(oldestLockedBlock.hash, (err, result) => {
+                        if (err) {
+                            return callback(err)
+                        }
                         oldestLockedBlock.height = result.height;
                         console.log(`Got the oldest block`);
                         callback(null, oldestLockedBlock);
                     });
                 }
-             },
+            },
             function(oldestLockedBlock, callback){
                 global.coinFuncs.getLastBlockHeader(function(err, body){
+                    if (err) {
+                        return callback(err);
+                    }
                     if (oldestLockedBlock === null){
                         /*
                         If there's no locked blocks, then allow the system to scan from the PPS depth downwards if PPS
@@ -663,7 +669,11 @@ function Database(){
                 });
                 callback(null, blockList);
             }
-        ], function(err, data){
+        ], function(err, data) {
+            if (err) {
+                console.error(err)
+                return
+            }
             if (global.config.general.blockCleaner === true){
                 if(data.length > 0){
                     global.database.refreshEnv();
@@ -677,8 +687,7 @@ function Database(){
                     });
                     console.log("Block cleaning enabled.  Removed: " +totalDeleted+ " block share records");
                 }
-                global.database.env.sync(function(){
-                });
+                global.database.env.sync(() => {});
             } else {
                 console.log("Block cleaning disabled.  Would have removed: " + JSON.stringify(data));
             }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -155,25 +155,24 @@ function checkAliveMiners() {
 }
 
 function templateUpdate(repeating) {
-    global.coinFuncs.getBlockTemplate(global.config.pool.address, function (rpcResponse) {
-        if (rpcResponse && typeof rpcResponse.result !== 'undefined') {
-            rpcResponse = rpcResponse.result;
-            let buffer = new Buffer(rpcResponse.blocktemplate_blob, 'hex');
-            let new_hash = new Buffer(32);
-            buffer.copy(new_hash, 0, 7, 39);
-            if (!activeBlockTemplate || new_hash.toString('hex') !== activeBlockTemplate.previous_hash.toString('hex')) {
-                debug(threadName + "New block template found at " + rpcResponse.height + " height with hash: " + new_hash.toString('hex'));
-                if (cluster.isMaster) {
-                    sendToWorkers({type: 'newBlockTemplate', data: rpcResponse});
-                    newBlockTemplate(rpcResponse);
-                } else {
-                    process.send({type: 'newBlockTemplate', data: rpcResponse});
-                    newBlockTemplate(rpcResponse);
-                }
-            }
-        } else {
+    global.coinFuncs.getBlockTemplate(global.config.pool.address, function (err, blockTemplate) {
+        if (err) {
             if (repeating !== true) {
                 setTimeout(templateUpdate, 300);
+            }
+            return
+        }
+        let buffer = new Buffer(blockTemplate.blocktemplate_blob, 'hex');
+        let new_hash = new Buffer(32);
+        buffer.copy(new_hash, 0, 7, 39);
+        if (!activeBlockTemplate || new_hash.toString('hex') !== activeBlockTemplate.previous_hash.toString('hex')) {
+            debug(threadName + "New block template found at " + blockTemplate.height + " height with hash: " + new_hash.toString('hex'));
+            if (cluster.isMaster) {
+                sendToWorkers({type: 'newBlockTemplate', data: blockTemplate});
+                newBlockTemplate(blockTemplate);
+            } else {
+                process.send({type: 'newBlockTemplate', data: blockTemplate});
+                newBlockTemplate(blockTemplate);
             }
         }
     });

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -16,12 +16,10 @@ function updateShareStats() {
     let activeAddresses = [];
     async.waterfall([
         function (callback) {
-            global.coinFuncs.getLastBlockHeader(function (err, body) {
-                if (err !== null){
-                    return callback(err, "Invalid block header");
-                }
-                callback(null, body.height + 1);
-            });
+            global.coinFuncs.getLastBlockHeader((err, block) => err
+                ? callback(err)
+                : callback(null, block.height + 1)
+            );
         },
         function (height, callback) {
             let locTime = Date.now() - 600000;
@@ -505,18 +503,25 @@ function updateWalletStats() {
 }
 
 function monitorNodes() {
-    global.mysql.query("SELECT blockID, hostname, ip FROM pools WHERE last_checkin > date_sub(now(), interval 30 minute)").then(function (rows) {
-        global.coinFuncs.getLastBlockHeader(function (err, block) {
-            if (err !== null){
-                console.error("Issue in getting block header.  Skipping node monitor");
-                return;
-            }
-            rows.forEach(function (row) {
-                    if (row.blockID < block.height - 3) {
-                        global.support.sendEmail(global.config.general.adminEmail, "Pool server behind in blocks", "The pool server: "+row.hostname+" with IP: "+row.ip+" is "+(block.height - row.blockID)+ " blocks behind");
-                    }
-                }
+    const sql = 'SELECT blockID AS blockId, hostname, ip FROM pools WHERE last_checkin > DATE_SUB(NOW(), INTERVAL 30 MINUTE)';
+    global.coinFuncs.getLastBlockHeader((err, block) => {
+        if (err) {
+            return global.support.sendEmail(
+                global.config.general.adminEmail,
+                'Failed to query daemon for last block header',
+                `The worker failed to return last block header. Please verify if the daemon is running properly.`
             );
+        }
+        global.mysql.query(sql).then(pools => {
+            pools.forEach(({ blockId, hostname, ip }) => {
+                if (blockId < block.height - 3) {
+                    global.support.sendEmail(
+                        global.config.general.adminEmail,
+                        'Pool server behind in blocks',
+                        `The pool server: ${hostname} with IP: ${ip} is ${(block.height - pool.blockId)} blocks behind.`
+                    );
+                }
+            })
         });
     });
 }


### PR DESCRIPTION
`getBlockTemplate` now returns an error when the RPC does not contain a result.

Checking for a callback error is done: `if (err) { ... }` instead of `if (err !== null) { ... }`

The worker now sends an email when it cannot get last block height when checking if server is behind in blocks. This solves my issue where I received an email indicating that I was `NaN blocks behind`

I renamed `getBlockHeaderByID` to `getBlockHeaderByHeight` to match the RPC request name. Also this function is not used at the moment anywhere else in the code.