### PR TITLE
Prevent pool crash when password is null

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -213,6 +213,8 @@ function Miner(id, login, pass, ipAddress, startingDiff, messageSender, protoVer
     // If the password is x, aka, old-logins, we're not going to allow detailed review of miners.
 
     // Miner Variables
+    // prevent pool crash when pass is null
+    if (!pass) pass = 'x';
     let pass_split = pass.split(":");
     this.error = "";
     this.identifier = pass_split[0];


### PR DESCRIPTION
When miner password is null, pool module will crash. So prevent it by using default value 'x'